### PR TITLE
fixed path replacement on platform dependent file object to use platform path separator

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,12 +34,14 @@ const {series, parallel, src, dest} = require('gulp');
 const flatmap = require('gulp-flatmap');
 const closureCompiler = require('google-closure-compiler').gulp();
 const cleanCss = require('gulp-clean-css');
+const path = require('path');
 
 const CM_ROOT = 'CodeMirror/';
+const CM_ROOT_PLATFORM_SEP = 'CodeMirror'+path.sep;
 
 function runFlatMap() {
   return flatmap((stream, file) => {
-    const pathAtCmRoot = file.relative.replace(CM_ROOT, '');
+    const pathAtCmRoot = file.relative.replace(CM_ROOT_PLATFORM_SEP, '');
     // Travis kills a build if no log output for 10 minutes
     console.log('Minifying ' + pathAtCmRoot);
     return stream.pipe(closureCompiler({


### PR DESCRIPTION
  This fixes the file to work correctly on windows.
  In the routine `runFlatMap()` the 'CodeMirror/' path is taken off of the `file.relative` filename so that the output files go in the correct place.  The problem is that the `file.relative` path/filename has platform dependent file separators within it and then it was having `.replace()` called on it with the path 'CodeMirror/', but on windows this needs to be 'CodeMirror\'.  
  This change simply makes a platform dependent version of the `CM_ROOT` constant with platform dependent separator on the end.  This is then used in the replace operation on the platform dependent filename.
 